### PR TITLE
Fix option visibility to be available outside package

### DIFF
--- a/pkg/broadcast/strings.go
+++ b/pkg/broadcast/strings.go
@@ -5,8 +5,8 @@ package broadcast
 // channels are closed when the input channel is closed.
 func Strings(in <-chan string, out []chan string, propagateClose bool) {
 	StringsWithOptions(in, out, StringOptions{
-		nonBlocking:    false,
-		propagateClose: propagateClose,
+		NonBlocking:    false,
+		PropagateClose: propagateClose,
 	})
 }
 
@@ -14,10 +14,10 @@ func Strings(in <-chan string, out []chan string, propagateClose bool) {
 // StringsWithOptions function.
 type StringOptions struct {
 	// If true, messages will be discarded rather than blocking the channel
-	nonBlocking bool
+	NonBlocking bool
 	// If propagateClose is true, then a close message on the input
 	// will be broadcast to all output channels
-	propagateClose bool
+	PropagateClose bool
 }
 
 // StringsWithOptions creates a new broadcast between the in string channel and
@@ -29,7 +29,7 @@ func StringsWithOptions(in <-chan string, out []chan string, opts StringOptions)
 	go func() {
 		for str := range in {
 			for _, c := range out {
-				if opts.nonBlocking {
+				if opts.NonBlocking {
 					select {
 					case c <- str:
 					default:
@@ -40,7 +40,7 @@ func StringsWithOptions(in <-chan string, out []chan string, opts StringOptions)
 			}
 		}
 
-		if opts.propagateClose {
+		if opts.PropagateClose {
 			for _, c := range out {
 				close(c)
 			}

--- a/pkg/broadcast/strings_test.go
+++ b/pkg/broadcast/strings_test.go
@@ -81,8 +81,8 @@ func TestStringsWithOptionsNonBlocking(t *testing.T) {
 	couts := []chan string{cout1, cout2}
 
 	StringsWithOptions(cin, couts, StringOptions{
-		nonBlocking:    true,
-		propagateClose: true,
+		NonBlocking:    true,
+		PropagateClose: true,
 	})
 	defer func() {
 		close(cin)
@@ -99,8 +99,8 @@ func TestStringsWithOptionsNonBlockingWithBufferedChannels(t *testing.T) {
 	couts := []chan string{cout1, cout2}
 
 	StringsWithOptions(cin, couts, StringOptions{
-		nonBlocking:    true,
-		propagateClose: true,
+		NonBlocking:    true,
+		PropagateClose: true,
 	})
 	defer func() {
 		close(cin)


### PR DESCRIPTION
Fix for new functionality for `broadcast.StringsWithOptions`. Previous functionality was still working, but setting options outside package was not.